### PR TITLE
fix: improve null check for timeout duration parameter of repel command

### DIFF
--- a/src/commands/moderation/repel.ts
+++ b/src/commands/moderation/repel.ts
@@ -431,7 +431,7 @@ export const repelCommand = createCommand({
 
       const timeout = await handleTimeout({
         target: target,
-        durationInMilliseconds: timeoutHours ? timeoutHours * HOUR : DEFAULT_TIMEOUT_DURATION_MS,
+        durationInMilliseconds: timeoutHours !== null ? timeoutHours * HOUR : DEFAULT_TIMEOUT_DURATION_MS,
       });
 
       const channels = getTextChannels(interaction);


### PR DESCRIPTION
Previously, setting a timeout duration of `0` would apply the default timeout duration because of a faulty null check. This PR fixes that check.

See this Discord conversation for further context: https://discord.com/channels/434487340535382016/1403558160144531589/1442471737735254098